### PR TITLE
feat: update opportunity service to prevent inheriting attention camp…

### DIFF
--- a/src/opportunity/opportunity.service.ts
+++ b/src/opportunity/opportunity.service.ts
@@ -497,6 +497,8 @@ export class OpportunityService {
       if (userToAssign) payload.assignedUserId = userToAssign;
       if (dto.observation) payload.cObs = dto.observation;
       if (campusId != null) payload.cCampusId = campusId;
+      // No heredar sede de atención del titular: el ejecutivo la confirma en CRM (modal) o en portal.
+      payload.cCampusAtencionId = null;
 
       const opportunity = this.opportunityRepository.create(payload);
       const saved = await this.opportunityRepository.save(opportunity);
@@ -636,6 +638,8 @@ export class OpportunityService {
         // original al inferir por número de teléfono. Ver
         // sv-backend-main/.../clinic-history-crm.service.ts#getRedirectByOpportunityId
         cIsReferralCreation: true,
+        // Sede de atención debe elegirse en CRM (Gestiona) o en la tarjeta de referido; no copiar del titular.
+        cCampusAtencionId: null,
       }
       
       const opportunityCreated = this.opportunityRepository.create(payloadOpportunity);


### PR DESCRIPTION
…us from the holder

- Set cCampusAtencionId to null to ensure the attention campus is selected in CRM or referral card, rather than inherited from the holder.
- Enhanced comments for clarity on the selection process for attention campus during opportunity creation.