### PR TITLE
feat: update opportunity crons service to utilize assignment queue st…

### DIFF
--- a/src/opportunity/opportunity-crons.service.ts
+++ b/src/opportunity/opportunity-crons.service.ts
@@ -241,12 +241,28 @@ export class OpportunityCronsService {
           assigned_user_user_name: user.userName || '',
         };
       } else {
-        // Primera asignación del batch: consultar BD usando la misma sede
-        lastOpportunityAssigned =
-          await this.opportunityService.getLastOpportunityAssigned(
-            subCampaignId,
-            campusId,
-          );
+        // Primera asignación del batch: usar assignment_queue_state como fuente
+        // única de verdad (igual que getNextUserToAssign en el flujo normal).
+        const campusIdForState = campusId ?? 0;
+        const state = await this.assignmentQueueStateService.getState(campusIdForState, subCampaignId);
+        if (state) {
+          let lastUserName = listUsers.find((u) => u.id === state.lastAssignedUserId)?.userName ?? '';
+          if (!lastUserName) {
+            const dbUser = await this.userService.findOne(state.lastAssignedUserId).catch(() => null);
+            lastUserName = dbUser?.userName ?? '';
+          }
+          lastOpportunityAssigned = {
+            assigned_user_id: state.lastAssignedUserId,
+            assigned_user_user_name: lastUserName,
+          };
+        } else {
+          // Fallback solo si no existe state en la cola aún
+          lastOpportunityAssigned =
+            await this.opportunityService.getLastOpportunityAssigned(
+              subCampaignId,
+              campusId,
+            );
+        }
       }
 
       if (!lastOpportunityAssigned) {


### PR DESCRIPTION
…ate for user assignment

- Refactored logic to use assignment queue state as the primary source for user assignment, improving accuracy in tracking last assigned users.
- Implemented fallback mechanism to retrieve last assigned user from the opportunity service if no state is available, ensuring robustness in assignment handling.
- Enhanced comments for clarity on the new assignment logic and its implications.