### PR TITLE
feat: add current payment form data field to ContractPresave entity

### DIFF
--- a/src/opportunity/contract-presave.entity.ts
+++ b/src/opportunity/contract-presave.entity.ts
@@ -82,6 +82,12 @@ export class ContractPresave {
   registeredPayments: string; // JSON string con los pagos del Paso 2
 
   // ========================================
+  // FORMULARIO DE PAGO EN CURSO (JSON)
+  // ========================================
+  @Column({ name: "current_payment_form_data", type: "text", nullable: true })
+  currentPaymentFormData: string; // JSON string con los campos del formulario sin agregar
+
+  // ========================================
   // TIMESTAMPS
   // ========================================
   @CreateDateColumn({ name: "created_at" })


### PR DESCRIPTION
- Introduced a new column for storing JSON data related to the current payment form, enhancing the ability to track payment information before final submission.
- Updated comments to clarify the purpose of the new field within the context of the opportunity process.