### PR TITLE
refactor: update user comparison logic in opportunity crons service

### DIFF
--- a/src/opportunity/dto/contract-presave.dto.ts
+++ b/src/opportunity/dto/contract-presave.dto.ts
@@ -92,5 +92,12 @@ export class CreateContractPresaveDto {
   @IsOptional()
   @IsString()
   registeredPayments?: string;
+
+  // ========================================
+  // FORMULARIO DE PAGO EN CURSO (JSON string)
+  // ========================================
+  @IsOptional()
+  @IsString()
+  currentPaymentFormData?: string;
 }
 

--- a/src/opportunity/opportunity-crons.service.ts
+++ b/src/opportunity/opportunity-crons.service.ts
@@ -317,7 +317,7 @@ export class OpportunityCronsService {
       const cmp = lastUserName.localeCompare(
         user.userName ?? '',
         'es',
-        { sensitivity: 'base' },
+        { sensitivity: 'accent' },
       );
       if (cmp < 0) return user;
     }

--- a/src/user/utils/getNextUser.ts
+++ b/src/user/utils/getNextUser.ts
@@ -26,11 +26,13 @@ export const getNextUser = (listUsers: User[], lastOpportunityAssigned: Opportun
   // ── Caso 2: usuario fuera de la lista (ocupado/eliminado) ─────────────────
   // Recorremos la lista (ya ordenada alfabéticamente) y devolvemos el primero
   // cuyo nombre sea estrictamente posterior al del último asignado.
+  // Usamos sensitivity:'accent' para distinguir nombres que difieran en tildes/case,
+  // evitando empates que saltarían usuarios.
   for (const user of listUsers) {
     const cmp = lastUserName.localeCompare(
       user.userName ?? '',
       'es',
-      { sensitivity: 'base' },
+      { sensitivity: 'accent' },
     );
     if (cmp < 0) {
       // lastUserName < user.userName → este usuario es el siguiente en orden


### PR DESCRIPTION
- Changed locale comparison sensitivity from 'base' to 'accent' in the opportunity crons service to accurately distinguish between user names with different accents, improving user selection logic.
- Updated comments to clarify the rationale behind the change in comparison sensitivity.