### PR TITLE
feat: add endpoint to retrieve opportunities by phone number

### DIFF
--- a/src/opportunity/opportunity.controller.ts
+++ b/src/opportunity/opportunity.controller.ts
@@ -632,6 +632,16 @@ export class OpportunityController {
     return this.opportunityService.getAllOpportunitiesByDocument(documentNumber);
   }
 
+  @Public()
+  @Get('get-all-by-phone/:phoneNumber')
+  async getAllByPhone(
+    @Headers('x-internal-api-key') apiKey: string,
+    @Param('phoneNumber') phoneNumber: string,
+  ) {
+    this.assertInternalApiKey(apiKey);
+    return this.opportunityService.getAllOpportunitiesByPhone(phoneNumber);
+  }
+
   /**
    * Crea oportunidad desde el flujo SV (mismo pipeline que `register` pero
    * sin requerir JWT). El `userId` se resuelve a un user bridge configurado.

--- a/src/opportunity/opportunity.service.ts
+++ b/src/opportunity/opportunity.service.ts
@@ -2574,6 +2574,19 @@ export class OpportunityService {
     });
   }
 
+  async getAllOpportunitiesByPhone(phoneNumber: string): Promise<Opportunity[]> {
+    const digits = phoneNumber.replace(/\D/g, '').slice(-9);
+    if (!digits) return [];
+    return this.opportunityRepository.find({
+      where: {
+        cNumeroDeTelefono: ILike(`%${digits}%`),
+        deleted: false,
+      },
+      relations: ['assignedUserId'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
   async getOpportunityByClinicHistory(clinicHistory: string) {
     const opportunities = await this.opportunityRepository.find({
       where: { cClinicHistory: clinicHistory, deleted: false },


### PR DESCRIPTION
- Introduced a new endpoint in OpportunityController to fetch all opportunities associated with a given phone number.
- Implemented the corresponding service method in OpportunityService to handle the phone number retrieval logic, including sanitization and filtering of results.