### PR TITLE
feat: restrict access to solicitudes and enhance patient access valid…

### DIFF
--- a/src/crm-cerradoras/crm-cerradoras.controller.ts
+++ b/src/crm-cerradoras/crm-cerradoras.controller.ts
@@ -60,10 +60,9 @@ export class CrmCerradoresController {
 
   /**
    * GET /crm-cerradoras/solicitudes
-   * Lista de solicitudes de demora.
-   * - Admin: ve todas.
-   * - Cerradora: ve solo las suyas.
+   * Lista de solicitudes de demora (revisión). Solo administradores CRM.
    */
+  @UseGuards(AdminUserGuard)
   @Get('solicitudes')
   async getSolicitudes(@Request() req: { user?: { userId?: string } }) {
     return this.cerradoresService.getSolicitudes(req.user?.userId ?? '');

--- a/src/crm-cerradoras/crm-cerradoras.service.ts
+++ b/src/crm-cerradoras/crm-cerradoras.service.ts
@@ -130,6 +130,16 @@ export class CrmCerradoresService {
     };
   }
 
+  private async assertMisPacientesAccess(userId: string): Promise<void> {
+    const isAdmin = await this.isAdmin(userId);
+    if (isAdmin) return;
+    const roles = await this.userService.getRoleIds(userId);
+    if (roles.includes(ROLES_IDS.CERRADORA)) return;
+    throw new ForbiddenException(
+      'Solo usuarios cerradoras o administradores pueden acceder a Mis Pacientes',
+    );
+  }
+
   async getPacientesCerradora(
     userId: string,
     params: ListPacientesContratosParams = {},
@@ -141,6 +151,7 @@ export class CrmCerradoresService {
     docusealProductionDate: string;
   }> {
     try {
+      await this.assertMisPacientesAccess(userId);
       return await this.listPacientesContratos(userId, {
         ...params,
         filterByAssignedUser: true,
@@ -222,14 +233,16 @@ export class CrmCerradoresService {
     };
   }
 
-  /** Obtiene solicitudes de demora. Admin ve todas; cerradora solo las suyas. */
+  /** Lista de solicitudes de demora para revisión. Solo administradores CRM. */
   async getSolicitudes(userId: string): Promise<{ data: CrmCerradoraSolicitud[]; pendientes: number }> {
     const admin = await this.isAdmin(userId);
-    const userInfo = await this.getUserInfo(userId);
+    if (!admin) {
+      throw new ForbiddenException(
+        'Solo administradores pueden ver el listado de solicitudes de demora',
+      );
+    }
 
-    const where = admin ? {} : { cerradoraUsername: userInfo.username };
     const data = await this.solicitudRepo.find({
-      where,
       order: { createdAt: 'DESC' },
     });
 


### PR DESCRIPTION
…ation

- Updated the getSolicitudes method to restrict access, allowing only CRM administrators to view the list of delay requests.
- Introduced a new private method, assertMisPacientesAccess, to validate user access for patient-related data, ensuring only authorized users can access their patients.
- Enhanced comments for clarity on access restrictions and the intended functionality of the methods.