### PR TITLE
feat: add apnea cortesia functionality to Opportunity module

### DIFF
--- a/migraciones/1749500000000-OpportunityApneaCortesia.ts
+++ b/migraciones/1749500000000-OpportunityApneaCortesia.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Flags para la promoción "Apnea de cortesía" en flujo completado (manager_leads).
+ * - c_apnea_cortesia_tomada: el ejecutivo solicitó la entrega desde el botón.
+ * - c_apnea_cortesia_entregada: la cortesía ya fue entregada físicamente.
+ */
+export class OpportunityApneaCortesia1749500000000 implements MigrationInterface {
+  name = 'OpportunityApneaCortesia1749500000000';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE opportunity
+        ADD COLUMN IF NOT EXISTS c_apnea_cortesia_tomada BOOLEAN NOT NULL DEFAULT false,
+        ADD COLUMN IF NOT EXISTS c_apnea_cortesia_entregada BOOLEAN NOT NULL DEFAULT false
+    `);
+
+    await queryRunner.query(`
+      COMMENT ON COLUMN opportunity.c_apnea_cortesia_tomada IS
+        'TRUE cuando el ejecutivo hizo clic en ENTREGAR APNEA DE CORTESÍA (solicitud registrada).'
+    `);
+
+    await queryRunner.query(`
+      COMMENT ON COLUMN opportunity.c_apnea_cortesia_entregada IS
+        'TRUE cuando la apnea de cortesía ya fue entregada físicamente al paciente.'
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE opportunity
+        DROP COLUMN IF EXISTS c_apnea_cortesia_tomada,
+        DROP COLUMN IF EXISTS c_apnea_cortesia_entregada
+    `);
+  }
+}

--- a/src/opportunity/dto/update-opportunity.dto.ts
+++ b/src/opportunity/dto/update-opportunity.dto.ts
@@ -285,6 +285,14 @@ export class UpdateOpportunityDto {
   cCampaign1Id?: string;
 
   @IsOptional()
+  @IsBoolean()
+  cApneaCortesiaTomada?: boolean;
+
+  @IsOptional()
+  @IsBoolean()
+  cApneaCortesiaEntregada?: boolean;
+
+  @IsOptional()
   @IsDateString()
   createdAt?: string;
 

--- a/src/opportunity/opportunity.controller.ts
+++ b/src/opportunity/opportunity.controller.ts
@@ -78,6 +78,12 @@ export class OpportunityController {
     const redirectResponse = await this.opportunityService.redirectToManager(usuario, uuidOpportunity, oiDerived);
     let response = redirectResponse;
 
+    const opportunityRecord = await this.opportunityService.findOne(uuidOpportunity);
+    const apneaCortesiaFlags = {
+      cApneaCortesiaTomada: opportunityRecord?.cApneaCortesiaTomada ?? false,
+      cApneaCortesiaEntregada: opportunityRecord?.cApneaCortesiaEntregada ?? false,
+    };
+
     try {
       const alreadyInvoiced = await this.opportunityPresaveService.checkIfAlreadyInvoiced(uuidOpportunity);
       const isComplete = await this.opportunityService.isCompleteForRedirect(uuidOpportunity);
@@ -176,7 +182,7 @@ export class OpportunityController {
     }
 
     console.log('[GET /opportunity/redirect] Respuesta', JSON.stringify(response, null, 2));
-    return response;
+    return { ...response, ...apneaCortesiaFlags };
   }
 
   @Public()
@@ -475,6 +481,14 @@ export class OpportunityController {
     @Body() body: UpdateSedeAtencionDto,
   ): Promise<Opportunity> {
     return this.opportunityService.updateSedeAtencion(id, body.campusAtencionId ?? null, body.campusName);
+  }
+
+  /** Registra solicitud de apnea de cortesía (promoción 16–30/06/2026, hora Lima). */
+  @Patch(':id/apnea-cortesia/tomar')
+  async marcarApneaCortesiaTomada(
+    @Param('id') id: string,
+  ): Promise<{ ok: boolean; cApneaCortesiaTomada: boolean }> {
+    return this.opportunityService.marcarApneaCortesiaTomada(id);
   }
 
   @Patch(':id')

--- a/src/opportunity/opportunity.entity.ts
+++ b/src/opportunity/opportunity.entity.ts
@@ -274,4 +274,12 @@ export class Opportunity {
    */
   @Column({ type: 'varchar', length: 60, nullable: true, name: 'c_facturacion_sub_estado' })
   cFacturacionSubEstado?: string;
+
+  /** TRUE cuando el ejecutivo solicitó apnea de cortesía desde manager_leads */
+  @Column({ type: 'boolean', nullable: false, default: false, name: 'c_apnea_cortesia_tomada' })
+  cApneaCortesiaTomada?: boolean;
+
+  /** TRUE cuando la apnea de cortesía ya fue entregada físicamente */
+  @Column({ type: 'boolean', nullable: false, default: false, name: 'c_apnea_cortesia_entregada' })
+  cApneaCortesiaEntregada?: boolean;
 }

--- a/src/opportunity/opportunity.service.ts
+++ b/src/opportunity/opportunity.service.ts
@@ -28,6 +28,7 @@ import { FilesService } from 'src/files/files.service';
 import { UpdateMeetingDto } from 'src/meeting/dto/update.dto';
 import { ENUM_TARGET_TYPE } from 'src/action-history/dto/enum-target-type';
 import { EnumCodeFlow } from './dto/enumCodeManage';
+import { isApneaCourtesyWindowActive } from './utils/apneaCourtesyWindow';
 import { CampaignService } from 'src/campaign/campaign.service';
 import {
   PatientIsNewCrmResponse,
@@ -2758,6 +2759,34 @@ export class OpportunityService {
     }
 
     return redirectResponse;
+  }
+
+  async marcarApneaCortesiaTomada(opportunityId: string): Promise<{ ok: boolean; cApneaCortesiaTomada: boolean }> {
+    if (!isApneaCourtesyWindowActive()) {
+      throw new BadRequestException('La promoción de apnea de cortesía no está activa en este momento');
+    }
+
+    const opportunity = await this.opportunityRepository.findOne({
+      where: { id: opportunityId, deleted: false },
+    });
+    if (!opportunity) {
+      throw new NotFoundException('No se encontró la oportunidad');
+    }
+
+    if (opportunity.cSubCampaignId !== CAMPAIGNS_IDS.APNEA && opportunity.cSubCampaignId !== CAMPAIGNS_IDS.OFM) {
+      throw new BadRequestException('La promoción de apnea de cortesía solo aplica a oportunidades OFM o APNEA');
+    }
+
+    if (opportunity.cApneaCortesiaTomada) {
+      return { ok: true, cApneaCortesiaTomada: true };
+    }
+
+    await this.opportunityRepository.update(
+      { id: opportunityId },
+      { cApneaCortesiaTomada: true, modifiedAt: new Date() },
+    );
+
+    return { ok: true, cApneaCortesiaTomada: true };
   }
 
 

--- a/src/opportunity/utils/apneaCourtesyWindow.ts
+++ b/src/opportunity/utils/apneaCourtesyWindow.ts
@@ -1,0 +1,28 @@
+const LIMA_TZ = 'America/Lima';
+
+/** Ventana promocional: 16/06/2026 00:00:00 – 30/06/2026 23:59:59 (hora Lima) */
+const WINDOW_START = 20260616000000;
+const WINDOW_END = 20260630235959;
+
+function getLimaDateTimeNumber(date: Date): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: LIMA_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date);
+
+  const v = (type: string) => parts.find((p) => p.type === type)?.value.padStart(2, '0') ?? '00';
+  return Number(
+    `${v('year')}${v('month')}${v('day')}${v('hour')}${v('minute')}${v('second')}`,
+  );
+}
+
+export function isApneaCourtesyWindowActive(now: Date = new Date()): boolean {
+  const limaNow = getLimaDateTimeNumber(now);
+  return limaNow >= WINDOW_START && limaNow <= WINDOW_END;
+}


### PR DESCRIPTION
- Introduced new fields `cApneaCortesiaTomada` and `cApneaCortesiaEntregada` in the Opportunity entity to track courtesy apnea requests.
- Implemented `marcarApneaCortesiaTomada` method in OpportunityService to handle the marking of courtesy apnea requests.
- Updated OpportunityController to return apnea cortesia flags in the redirect response.
- Enhanced UpdateOpportunityDto to include optional fields for apnea cortesia status.