### PR TITLE
refactor: update optional fields in OpportunityServiceOrder and clini…

### DIFF
--- a/src/opportunity/dto/clinic-history.ts
+++ b/src/opportunity/dto/clinic-history.ts
@@ -1,12 +1,12 @@
 export interface CreateClinicHistoryCrmDto {
   espoId: string;
-  id_payment?: number;
-  id_reservation?: number;
+  id_payment?: number | null;
+  id_reservation?: number | null;
   patientId?: number;
 }
 
 export interface UpdateClinicHistoryCrmDto {
-  id_payment?: number;
-  id_reservation?: number;
+  id_payment?: number | null;
+  id_reservation?: number | null;
   patientId?: number;
 }

--- a/src/opportunity/opportunity-service-order.entity.ts
+++ b/src/opportunity/opportunity-service-order.entity.ts
@@ -42,13 +42,13 @@ export class OpportunityServiceOrder {
   facturado?: boolean;
 
   @Column({ type: 'integer', nullable: true, name: 'invoice_result_head_id' })
-  invoiceResultHeadId?: number;
+  invoiceResultHeadId?: number | null;
 
   @Column({ type: 'text', nullable: true, name: 'url_soles' })
-  urlSoles?: string;
+  urlSoles?: string | null;
 
   @Column({ type: 'text', nullable: true, name: 'url_dolares' })
-  urlDolares?: string;
+  urlDolares?: string | null;
 
   @Column({ type: 'timestamp with time zone', nullable: true, name: 'last_checked_at' })
   lastCheckedAt?: Date;


### PR DESCRIPTION
…c history DTOs to allow null values

- Modified OpportunityServiceOrder entity and Create/UpdateClinicHistoryCrmDto interfaces to accept null for optional fields, enhancing data flexibility and consistency.